### PR TITLE
Fixed bugs and added a p/v interface for linear superconcentrators

### DIFF
--- a/linear_pebble.py
+++ b/linear_pebble.py
@@ -98,7 +98,7 @@ class PebbleGraph:
                 print "Error: Attempted to pebble node " + str(v) + " but it has already been pebbled"
 
         else: # This is not for testing, but to run linear_pebble_graph_trivial as fast as possible.
-            if v is "\00" * self.all_graphs_increment:
+            if v == "\00" * self.all_graphs_increment:
                 return
             if v < 64 * 2**self.graph_num:
                 self.pebble_value.write(utils.secure_hash(str(v)))

--- a/linear_superconcentrator.py
+++ b/linear_superconcentrator.py
@@ -47,7 +47,7 @@ def expander_graph(n, addend, expander_parents, extra, beginning, graph_incremen
                 parents[g] += addend + extra
                 zeroes.append(graph_increment - len(str(parents[g])))
             if n > 128 and n + addend <= i and i < addend + n*3/2:
-                zeroes.append(graph_increment - (addend + extra + i + n/2))
+                zeroes.append(graph_increment - len(str(addend + extra + i + n/2)))
                 expander_parents.write("0" * zeroes[0] + str(parents[0]) + "0" * zeroes[1] + str(parents[1]) + "0" * zeroes[2] + str(parents[2]) +
                                        "0" * zeroes[3] + str(parents[3]) + "0" * zeroes[4] + str(parents[4]) + "0" * zeroes[5] + str(parents[5]) + "0" * zeroes[6] + str(addend + extra + i + n/2))
             else:

--- a/pebble.py
+++ b/pebble.py
@@ -13,14 +13,16 @@ class PebbleGraph:
         self.num_pebbles = 0                                           # num_pebbles is the number of pebbles currently on the graph.
         self.max_pebbles = 0                                           # max_pebbles it the maximum number of pebbles that have been on the graph since the last reset.
         self.graph_num = r
+        self.size =  ptc.ptcsize(self.graph_num)
         if not pre_generated_graph:
             all_graphs.seek(0)
             ptc.PTC(r, self.all_graphs)
-        self.all_graphs_increment = len(str(ptc.ptcsize(self.graph_num))) # The number of bytes each parent in all_graphs takes
+        self.all_graphs_increment = len(str(self.size)) # The number of bytes each parent in all_graphs takes
         self.all_graphs_start = ptc.all_graphs_start(self.graph_num) # The position where the rth graph is stored in all_graphs.
         self.all_graphs.seek(self.all_graphs_start + 2 * 2**self.graph_num * self.all_graphs_increment)
         self.pebble_value.seek(0)
-        self.pebble_value.write("\00"*self.hash_length * self.size())
+        for i in range(self.size):
+            self.pebble_value.write("\00"*self.hash_length)
         self.pebble_value.seek(0)
         self.debug = debug
 
@@ -51,7 +53,7 @@ class PebbleGraph:
 
     def reset(self):
         self.pebble_value.seek(0)
-        for i in range(self.size()):
+        for i in range(self.size):
             self.pebble_value.write("\00"*self.hash_length)
         self.num_pebbles = 0
         self.max_pebbles = 0
@@ -130,13 +132,10 @@ class PebbleGraph:
         parents = [self.all_graphs.read(all_graphs_increment), self.all_graphs.read(all_graphs_increment)]
         return parents
 
-    def size(self):
-        return ptc.ptcsize(self.graph_num)
-
     def print_graph(self):
         self.all_graphs.seek(self.all_graphs_start)
         print "[",
-        for i in range(self.size()):
+        for i in range(self.size):
             print "[" + self.all_graphs.read(self.all_graphs_increment) + ", " + self.all_graphs.read(self.all_graphs_increment) + "]",
         print "]"
 
@@ -149,7 +148,7 @@ class PebbleGraph:
     def list_values(self): # I noticed that since values does not use persistent storage, this will fail for large graphs.
         values = []
         self.pebble_value.seek(0)
-        for i in range(self.size()):
+        for i in range(self.size):
             values.append(self.pebble_value.read(self.hash_length))
         return values
 

--- a/pebbling_algos.py
+++ b/pebbling_algos.py
@@ -1,4 +1,3 @@
-
 import pebble
 import utils
 import ptc
@@ -49,7 +48,7 @@ def dfp(P, v, S):
         if not P.is_pebbled(u):
             dfp(P, u, S | set(P.get_parents(v)))
     P.add_pebble(v)
-    P.remove_pebbles(set(range(P.size())) - S)
+    P.remove_pebbles(set(range(P.size)) - S)
 
 # LEVEL PEBBLE METHOD, intuitively graph level by level
 # v does nothing at this point

--- a/ptc.py
+++ b/ptc.py
@@ -13,7 +13,8 @@ def PTC(r, all_parents):
         ptc_size = ptcsize(graph_num-1)
 
         # Adds Sources
-        all_parents.write("\00\00" * graph_increment * 2**graph_num)
+        for i in range(2**graph_num):
+            all_parents.write("\00\00" * graph_increment)
                 
         # Adds 1st SC copy
         for i in range(2**(graph_num-1)):

--- a/sc.py
+++ b/sc.py
@@ -6,11 +6,6 @@ def butterfly(r, addend, parents):
     increment = len(str(ptc.ptcsize(r+1)))
 
     # We do not add the sources to the superconcentrator graph, as they are added in ptc.py
-    """
-    for i in range(2**r):
-        parents.write("\00" * 2 * increment)
-    # z signifies the lack of a parent
-    """
 
     # We store the parents as: [Parent directly below vertex, parent below and to the side of vertex.]
     for vertex in range (2**r, numvertices):

--- a/test.py
+++ b/test.py
@@ -1,4 +1,10 @@
-import pebble, pebbling_algos, trees, primitive_pv, linear_pebble, ptc, linear_ptc
+import pebbling_algos
+import primitive_pv
+import linear_primitive_pv
+import pebble
+import linear_pebble
+import ptc
+import linear_ptc
 import datetime
 import sys
 import re
@@ -42,6 +48,41 @@ def create_butterfly_graphs(n): # creates all butterfly PTC graphs up to and inc
     print "***************"
     all_graphs.close()
 
+def linear_primitive_pv_test(r, pre_gen_graph=False, debug=False):
+    beginning_time = time.time()
+    print "***************"
+    print "Running linear_pv_test("+str(r)+"), starting at " + str(datetime.datetime.now()) + "."
+    if debug:
+        print "Initializing prover..."
+    P = linear_primitive_pv.Prover(r, pre_gen_graph=pre_gen_graph, debug=debug)
+    second_time = time.time()
+    P.create_merkle_tree()
+    third_time = time.time()
+    if debug:
+        print "Prover initialization complete."
+        print "Initializing verifier..."
+    V = linear_primitive_pv.Verifier(r, debug=debug)
+    V.set_prover(P)
+    if debug:
+        print "Verifier initialization complete."
+        print "Commencing verification protocol."
+    result = V.verify()
+    fourth_time = time.time()
+    if result:
+        print "Honest prover verified successfully."
+    else:
+        print "Verification failed; prover will be denied."
+    print "Vertices in graph: " + str(linear_ptc.linear_ptcsize(r))
+    print "Seconds elapsed to generate/initialize PebbleGraph and pebble graph: " + str(second_time - beginning_time)
+    print "Seconds elapsed to create merkle tree: " + str(third_time - second_time)
+    print "Seconds elapsed to verify merkle tree: " + str(fourth_time - third_time)
+    print "Total seconds elapsed: " + str(fourth_time - beginning_time)
+    print "Total vertices / seconds elapsed: " + str(linear_ptc.linear_ptcsize(r) / (fourth_time - beginning_time))
+    print "linear_pv_test("+str(r)+") completed at "+ str(datetime.datetime.now()) + "."
+    print "***************"
+    P.close_files()
+
+    
 def primitive_pv_test(r, pre_gen_graph=False, debug=False):
     beginning_time = time.time()
     print "***************"
@@ -81,7 +122,7 @@ def merkle_test(r):
     print "Running merkle_test("+str(r)+"), starting at "+str(datetime.datetime.now())+"."
 
     p = pebble.PebbleGraph(r, debug=True)
-    pebbling_algos.trivial_pebble(p, p.size()-1)
+    pebbling_algos.trivial_pebble(p, p.size-1)
     print "Building Merkle tree..."
     mt = trees.MerkleNode(p.list_values())
     print "Merkle tree setup complete.  Root: "+mt.root()
@@ -95,7 +136,7 @@ def pebble_all_dfp(r):
     print("Running pebble_all_dfp("+str(r)+"), starting at "+str(datetime.datetime.now())+".")
 
     p = pebble.PebbleGraph(r, debug=True)
-    for i in range(p.size()):
+    for i in range(p.size):
         print("Pebbling vertex "+str(i))
         pebbling_algos.depth_first_pebble(p, i)
         if(p.is_pebbled(i)):
@@ -113,7 +154,7 @@ def pebble_all_trivial(r):
     print("Running pebble_all_trivial("+str(r)+").")
 
     p = pebble.PebbleGraph(r, debug=True)
-    for i in range(p.size()):
+    for i in range(p.size):
         print("Pebbling vertex "+str(i))
         pebbling_algos.trivial_pebble(p, i)
         if(p.is_pebbled(i)):
@@ -131,7 +172,7 @@ def pebble_sinks_dfp(r):
     print("Running pebble_sinks_dfp("+str(r)+"), starting at "+str(datetime.datetime.now())+".")
 
     p = pebble.PebbleGraph(r, debug=True)
-    for i in range(p.size()-2**r, p.size()): # just the sinks
+    for i in range(p.size-2**r, p.size): # just the sinks
         print("Pebbling vertex "+str(i))
         pebbling_algos.depth_first_pebble(p, i)
         if(p.is_pebbled(i)):
@@ -149,7 +190,7 @@ def pebble_sinks_trivial(r):
     print("Running pebble_sinks_trivial("+str(r)+"), starting at "+str(datetime.datetime.now())+".")
 
     p = pebble.PebbleGraph(r, debug=True)
-    for i in range(p.size()-2**r, p.size()): # just the sinks
+    for i in range(p.size-2**r, p.size): # just the sinks
         print("Pebbling vertex "+str(i))
         pebbling_algos.trivial_pebble(p, i)
         if(p.is_pebbled(i)):
@@ -182,18 +223,18 @@ def pebble_graph_trivial(r, pre_gen_graph=False, debug_flag=False):
     p = pebble.PebbleGraph(r, pre_generated_graph=pre_gen_graph, debug=debug_flag)
     end_generate = time.time()
     start_pebble = time.time()
-    pebbling_algos.trivial_pebble(p, p.size() - 1)
-    if p.is_pebbled(p.size() - 1):
+    pebbling_algos.trivial_pebble(p, p.size - 1)
+    if p.is_pebbled(p.size - 1):
         print "The final vertex in PTC(" + str(r) + ") was successfully pebbled."
     else:
         print "ERROR: The final vertex in PTC(" + str(r) + ") was not successfully pebbled."
-    print "Vertices in graph: " + str(p.size())
+    print "Vertices in graph: " + str(p.size)
     print "Seconds elapsed to generate graph: " + str(end_generate - start_generate)
-    print "Vertices generated per second: " + str(p.size() / (end_generate - start_generate))
+    print "Vertices generated per second: " + str(p.size / (end_generate - start_generate))
     print "Seconds elapsed to pebble graph: " + str(time.time() - start_pebble)
-    print "Vertices pebbled per second: " + str(p.size() / (time.time() - start_pebble))
+    print "Vertices pebbled per second: " + str(p.size / (time.time() - start_pebble))
     print "Total seconds elapsed: " + str(time.time() - start_generate)
-    print "Vertices generated and pebbled per second: " + str(p.size() / (time.time() - start_generate))
+    print "Vertices generated and pebbled per second: " + str(p.size / (time.time() - start_generate))
     print "pebble_graph_trivial(" + str(r) + ", pre_gen_graph=" + str(pre_gen_graph) + ") completed at " + str(datetime.datetime.now()) + "."
     print "***************"
     p.close_files()


### PR DESCRIPTION
The bugs were:
1. Every once in a while the linear superconcentrator code crashed during the pebbling process, because in a rare case the wrong number of leading zeroes were added in front of the parent number of a vertex in the expander graph function. This sometimes messed up the implicit storage of the graph.
2. One part of the code was incorrectly written to write large blocks of zero bytes at once to the file. Unfortunately, these blocks did not fit in memory for larger graphs, so I changed it so the code writes smaller blocks of zero bytes within a  loop.

Both of these bugs only showed up when running larger tests, which is why we haven't noticed them until now.
